### PR TITLE
Makefile: bump poetry's version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ help: ## Show this help
 install:  ## Install package
 	@echo "🏗️ Install package"
 	python -m pip install --upgrade pip
-	python -m pip install --upgrade poetry==1.2.0a2
+	python -m pip install --upgrade poetry==1.3.0
 	poetry install
 
 


### PR DESCRIPTION
I got the following error when running `make install`:

ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts. poetry-plugin-export 1.3.1 requires poetry<2.0.0,>=1.3.0, but you have poetry 1.2.0a2 which is incompatible.