### PR TITLE
Handle non-Exception BaseExceptions

### DIFF
--- a/asgi_logger/middleware.py
+++ b/asgi_logger/middleware.py
@@ -59,6 +59,9 @@ class AccessLoggerMiddleware:
         except Exception as exc:
             info["response"]["status"] = 500
             raise exc
+        except BaseException as exc:
+            info["response"]["status"] = None
+            raise exc
         finally:
             info["end_time"] = time.time()
             self.log(scope, info)


### PR DESCRIPTION
`BaseException`s that are not a subclass of `Exception` break the middleware, resulting in a `KeyError`. Starlette and FastAPI don't handle these in their `ServerErrorMiddleware`, either, so I think setting the status to `None` is reasonable. Another option would be to ignore these cases or log something different.

Fixes #42.